### PR TITLE
delete `form_images_list[index]` around image upload  申请退款时，上传图片部分报错

### DIFF
--- a/pages/user-orderaftersale-detail/user-orderaftersale-detail.vue
+++ b/pages/user-orderaftersale-detail/user-orderaftersale-detail.vue
@@ -169,7 +169,7 @@
                                     </view>
                                 </block>
                             </view>
-                            <image v-if="(form_images_list[index] || null) == null || form_images_list.length < 3" class="upload-icon" :src="common_static_url+'upload-icon.png'" mode="aspectFill" @tap="file_upload_event"></image>
+                            <image v-if="form_images_list.length < 3" class="upload-icon" :src="common_static_url+'upload-icon.png'" mode="aspectFill" @tap="file_upload_event"></image>
                         </view>
                     </view>
                     <view class="form-gorup form-gorup-submit">


### PR DESCRIPTION


`(form_images_list[index] || null) ` cause the error: 
```
vendor.js? [sm]:7462 [Vue warn]: Property or method "index" is not defined on the instance but referenced during render. Make sure that this property is reactive, either in the data option, or for class-based components, by initializing the property. See: https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties.

(found in pages/user-orderaftersale-detail/user-orderaftersale-detail.vue)(env: Windows,mp,1.06.2306020; lib: 2.32.3)
```

申请售后时，点击“仅退款”，就会出现此错误
![image](https://github.com/scil/shopxo-uniapp--watch/assets/2786775/c331870a-fa03-4fe5-9a01-c5ce2c6b8f1a)


补充：只修改了源代码中的172行，只是删除了涉及变量 'index'的部分，即：
```
(form_images_list[index] || null) == null || 
```

github里，显示很多行被修改了，只是 github 警告称“文件中有混合的换合符，强行用 windows 换行符替换“。
